### PR TITLE
All public methods (excepting start()) return the menu object, so 'ch…

### DIFF
--- a/lib/nodemenu.js
+++ b/lib/nodemenu.js
@@ -14,11 +14,25 @@ var NodeMenu = function() {
     self.menuItems = [];
     self.waitToContinue = false;
     self.itemNo = 0;
+    self.printDefaultHeader = true;
+};
+
+NodeMenu.prototype.enableDefaultHeader = function() {
+    var self = this;
+    self.printDefaultHeader = true;
+    return self;
+};
+
+NodeMenu.prototype.disableDefaultHeader = function() {
+    var self = this;
+    self.printDefaultHeader = false;
+    return self;
 };
 
 NodeMenu.prototype.addItem = function(title, handler, owner, args) {
     var self = this;
     self.menuItems.push(new MenuItem(MenuType.ACTION, ++self.itemNo, title, handler, owner, args));
+    return self;
 };
 
 NodeMenu.prototype.addDelimiter = function(delimiter, cnt, title) {
@@ -29,6 +43,7 @@ NodeMenu.prototype.addDelimiter = function(delimiter, cnt, title) {
     }
 
     self.menuItems.push(menuItem);
+    return self;
 }
 
 NodeMenu.prototype.start = function() {
@@ -126,7 +141,9 @@ NodeMenu.prototype._printMenu = function() {
 
     util.print(self.CLEAR_CODE);
     var self = this;
-    self._printHeader();
+    if (self.printDefaultHeader) {
+        self._printHeader();    
+    }
     for (var i = 0; i < self.menuItems.length; ++i) {
         var menuItem = self.menuItems[i];
         printableMenu = menuItem.getPrintableString();


### PR DESCRIPTION
- All public methods (excepting start()) return the menu object, so 'chained' expressions are allowed.
- There are 2 methods: enableDefaultHeader and disableDefaultHeader that can be used to specify the menu if the NodeMenu header should be displayed or not. It can be improved using ascii-art, but this library is async and it's implementation is not trivial.
