### PR TITLE
Add customizable prompt message

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add item to the menu. Returns __menu__ for chaining calls.
 
 ```javascript
 menu.addItem(
-    'Menu Item', 
+    'Menu Item',
     function(str, bool, num1, num2) {
         console.log('String: ' + str);
         if (bool) {
@@ -39,8 +39,8 @@ menu.addItem(
     },
     null,
     [
-        {'name': 'Str Arg', 'type': 'string'}, 
-        {'name': 'Bool Arg', 'type': 'bool'}, 
+        {'name': 'Str Arg', 'type': 'string'},
+        {'name': 'Bool Arg', 'type': 'bool'},
         {'name': 'num1', 'type': 'numeric'},
         {'name': 'num2', 'type': 'numeric'}
     ]);
@@ -51,14 +51,14 @@ menu.addItem(
 Adds delimiter to the menu. Returns __menu__ for chaining calls.
 
 - _delimiter_ - delimiter character;
-- _cnt_ - delimiter's repetition count; 
+- _cnt_ - delimiter's repetition count;
 - _title_ - title of the delimiter, will be printed in the middle of the delimiter line;
 
 The output of the delimiter:
 
     menu.addDelimiter('-', 33, 'Main Menu')
     ------------Main Menu------------
-    
+
     menu.addDelimiter('*', 33)
     *********************************
 
@@ -84,7 +84,33 @@ Turns off default header and prints custom header passed in __customHeaderFunc__
 
 ```javascript
 menu.customHeader(function() {
-    process.stdout.write("Custom header\n");
+    process.stdout.write("\nCustom header\n");
+})
+```
+
+### menu.enableDefaultPrompt()
+
+Turns on default prompt (turned on by default). Returns __menu__ for chaining calls.
+
+```javascript
+menu.enableDefaultPrompt()
+```
+
+### menu.disableDefaultPrompt()
+
+Turns off default prompt. No prompt will be printed in this case. Returns __menu__ for chaining calls.
+
+```javascript
+menu.disableDefaultPrompt()
+```
+
+### menu.customPrompt(customPromptFunc)
+
+Turns off default prompt and prints custom header passed in __customPromptFunc__. Returns __menu__ for chaining calls.
+
+```javascript
+menu.customPrompt(function() {
+    process.stdout.write("Custom prompt\n");
 })
 ```
 
@@ -121,7 +147,7 @@ var testObject = new TestObject();
 
 menu.addDelimiter('-', 40, 'Main Menu')
     .addItem(
-        'No parameters', 
+        'No parameters',
         function() {
             console.log('No parameters is invoked');
         })
@@ -135,15 +161,15 @@ menu.addDelimiter('-', 40, 'Main Menu')
         testObject,
         [{'name': 'arg1', 'type': 'string'}])
     .addItem(
-        'Sum', 
+        'Sum',
         function(op1, op2) {
             var sum = op1 + op2;
             console.log('Sum ' + op1 + '+' + op2 + '=' + sum);
         },
-        null, 
+        null,
         [{'name': 'op1', 'type': 'numeric'}, {'name': 'op2', 'type': 'numeric'}])
     .addItem(
-        'String and Bool parameters', 
+        'String and Bool parameters',
         function(str, b) {
             console.log("String is: " + str);
             console.log("Bool is: " + b);
@@ -155,6 +181,10 @@ menu.addDelimiter('-', 40, 'Main Menu')
     //     process.stdout.write("Hello\n");
     // })
     // .disableDefaultHeader()
+    // .customPrompt(function() {
+    //     process.stdout.write("\nEnter your selection:\n");
+    // })
+    // .disableDefaultPrompt()
     .start();
 ```
 
@@ -165,7 +195,7 @@ Output of this example:
       /  |/ // __ \ / __  // _ \ / /|_/ // _ \ / __ \ / / / /
      / /|  // /_/ // /_/ //  __// /  / //  __// / / // /_/ /
     /_/ |_/ \____/ \__,_/ \___//_/  /_/ \___//_/ /_/ \__,_/  v.1.0.0
-    
+
     ---------------Main Menu---------------
     1. No parameters
     2. Print Field A
@@ -174,9 +204,9 @@ Output of this example:
     5. String and Bool parameters: "str" "bool"
     ***************************************
     6. Quit
-    
+
     Please provide input at prompt as: >> ItemNumber arg1 arg2 ... (i.e. >> 2 "string with spaces" 2 4 noSpacesString true)
-      
-    >> 
+
+    >>
 
 To invoke item without arguments just type number and Enter. To invoke item with arguments, type number then arguments delimited with space. If string argument has spaces it must be double quoted.

--- a/examples/sample_menu.js
+++ b/examples/sample_menu.js
@@ -4,21 +4,21 @@ var TestObject = function() {
     var self = this;
     self.fieldA = 'FieldA';
     self.fieldB = 'FieldB';
-}
+};
 
 TestObject.prototype.printFieldA = function() {
     console.log(this.fieldA);
-}
+};
 
 TestObject.prototype.printFieldB = function(arg) {
     console.log(this.fieldB + arg);
-}
+};
 
 var testObject = new TestObject();
 
 menu.addDelimiter('-', 40, 'Main Menu')
     .addItem(
-        'No parameters', 
+        'No parameters',
         function() {
             console.log('No parameters is invoked');
         })
@@ -32,15 +32,15 @@ menu.addDelimiter('-', 40, 'Main Menu')
         testObject,
         [{'name': 'arg1', 'type': 'string'}])
     .addItem(
-        'Sum', 
+        'Sum',
         function(op1, op2) {
             var sum = op1 + op2;
             console.log('Sum ' + op1 + '+' + op2 + '=' + sum);
         },
-        null, 
+        null,
         [{'name': 'op1', 'type': 'numeric'}, {'name': 'op2', 'type': 'numeric'}])
     .addItem(
-        'String and Bool parameters', 
+        'String and Bool parameters',
         function(str, b) {
             console.log("String is: " + str);
             console.log("Bool is: " + b);
@@ -52,4 +52,8 @@ menu.addDelimiter('-', 40, 'Main Menu')
     //     process.stdout.write("Hello\n");
     // })
     // .disableDefaultHeader()
+    // .customPrompt(function() {
+    //     process.stdout.write("\nEnter your selection:\n");
+    // })
+    // .disableDefaultPrompt()
     .start();

--- a/lib/menuitem.js
+++ b/lib/menuitem.js
@@ -16,16 +16,17 @@ var MenuItem = function(menuType, number, title, handler, owner, args) {
 		self.delimiter = Array(80).join('-');
 	}
 
-	owner ? self.owner = owner : self.owner = self;
-	args ? self.args = args : self.args = [];
+	self.owner = owner ? owner : self;
+	self.args = args ? args : [];
 };
 
 MenuItem.prototype.validate = function(argv) {
 	var self  = this;
+	var res;
 
 	if (!argv) {
-		var res = {
-	    	lengthMatch: false, 
+		res = {
+	    	lengthMatch: false,
 	    	typesMatch: null
 	    };
 
@@ -51,12 +52,12 @@ MenuItem.prototype.validate = function(argv) {
 		}
 	}
 
-	var res = {
-    	lengthMatch: lengthMatch, 
+	res = {
+    	lengthMatch: lengthMatch,
     	typesMatch: typesMatch
     };
 
-    return res; 
+    return res;
 };
 
 MenuItem.prototype.getPrintableString = function() {

--- a/lib/nodemenu.js
+++ b/lib/nodemenu.js
@@ -16,6 +16,7 @@ var NodeMenu = function() {
     self.waitToContinue = false;
     self.itemNo = 0;
     self.printDefaultHeader = true;
+    self.printDefaultPrompt = true;
 };
 
 NodeMenu.prototype.enableDefaultHeader = function() {
@@ -35,7 +36,26 @@ NodeMenu.prototype.customHeader = function(customHeaderFunc) {
     self.printDefaultHeader = false;
     self.customHeaderFunc = customHeaderFunc;
     return self;
-}
+};
+
+NodeMenu.prototype.enableDefaultPrompt = function() {
+    var self = this;
+    self.printDefaultPrompt = true;
+    return self;
+};
+
+NodeMenu.prototype.disableDefaultPrompt = function() {
+    var self = this;
+    self.printDefaultPrompt = false;
+    return self;
+};
+
+NodeMenu.prototype.customPrompt = function(customPromptFunc) {
+    var self = this;
+    self.printDefaultPrompt = false;
+    self.customPromptFunc = customPromptFunc;
+    return self;
+};
 
 NodeMenu.prototype.addItem = function(title, handler, owner, args) {
     var self = this;
@@ -52,7 +72,7 @@ NodeMenu.prototype.addDelimiter = function(delimiter, cnt, title) {
 
     self.menuItems.push(menuItem);
     return self;
-}
+};
 
 NodeMenu.prototype.start = function() {
     var self = this;
@@ -119,7 +139,7 @@ NodeMenu.prototype._parseInput = function(text) {
         res.argv = match.slice(1);
         for (var i = 0; i < res.argv.length; ++i) {
             res.argv[i] = res.argv[i].replace(/"/g, '');
-            if (res.argv[i].trim != '') {
+            if (res.argv[i].trim !== '') {
                 var num = Number(res.argv[i]);
                 if (!isNaN(num)) {
                     res.argv[i] = num;
@@ -128,14 +148,14 @@ NodeMenu.prototype._parseInput = function(text) {
                 }
             }
         }
-    } 
+    }
 
     return res;
 };
 
 NodeMenu.prototype._printHeader = function() {
     var self = this;
-    
+
     if (self.printDefaultHeader) {
         process.stdout.write("                                                \n\
             _   __            __       __  ___                                \n\
@@ -150,12 +170,22 @@ NodeMenu.prototype._printHeader = function() {
     }
 };
 
+NodeMenu.prototype._printPrompt = function() {
+    var self = this;
+
+    if (self.printDefaultPrompt) {
+        self.consoleOutput('\nPlease provide input at prompt as: >> ItemNumber arg1 arg2 ... (i.e. >> 2 "string with spaces" 2 4 noSpacesString true)');
+    } else if (_.isFunction(self.customPromptFunc)) {
+        self.customPromptFunc();
+    }
+};
+
 NodeMenu.prototype._printMenu = function() {
     var self = this;
 
     util.print(self.CLEAR_CODE);
-    var self = this;
-    self._printHeader();    
+
+    self._printHeader();
     for (var i = 0; i < self.menuItems.length; ++i) {
         var menuItem = self.menuItems[i];
         printableMenu = menuItem.getPrintableString();
@@ -166,7 +196,7 @@ NodeMenu.prototype._printMenu = function() {
         }
     }
 
-    self.consoleOutput('\nPlease provide input at prompt as: >> ItemNumber arg1 arg2 ... (i.e. >> 2 "string with spaces" 2 4 noSpacesString true)');
+    self._printPrompt();
 
     process.stdout.write("\n>> ");
 };


### PR DESCRIPTION
This adds the ability to customize the prompt message that defaults to "Please provide input at prompt as: >> ItemNumber arg1 arg2 ... (i.e. >> 2 "string with spaces" 2 4 noSpacesString true)". This is implemented exactly like the customizable header, with comparable functions to set it up.

I updated the README.md file with these additions as well, following the same format as the header documentation.

This should close issue #5.