### PR TITLE
Upgrade underscore to fix CVE-2026-27601

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "node-menu",
+  "version": "1.3.4",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-menu",
+      "version": "1.3.4",
+      "license": "MIT",
+      "dependencies": {
+        "underscore": "1.13.8"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-menu",
   "description": "Allows to create command line menu for REPL applications",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "Borys Nebosenko <borys.nebosenko@gmail.com>",
   "keywords": [
   	"menu", 
@@ -12,7 +12,7 @@
   ],
   "repository": "git://github.com/nbu/node-menu",
   "dependencies": {
-  	"underscore": "1.6.0"
+  	"underscore": "1.13.8"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
## Summary
- Upgrade `underscore` from 1.6.0 to 1.13.8 to address CVE-2026-27601 (high severity)
- Bump package version to 1.3.4
- Add `package-lock.json` for reproducible installs

The library only uses stable underscore helpers (`isFunction`, `isFinite`, `isBoolean`), so this upgrade is expected to be backward compatible.

## Test plan
- [x] `npm install` completes with 0 reported vulnerabilities
- [x] `node -e "require('./index')"` loads successfully


Made with [Cursor](https://cursor.com)