### PR TITLE
Fix input parsing, global leak, and docs (1.3.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Clears all data and listeners from the menu object so the object can be updated 
 Set callback which must be invoked when __"Enter"__ button pressed to continue.
 
 ```javascript
-menu.resetMenu()
+menu.continueCallback(function () {
+    console.log('Continuing...');
+})
 ```
 
 ### menu.start()
@@ -225,7 +227,7 @@ Output of this example:
        / | / /____   ____/ /___   /  |/  /___   ____   __  __
       /  |/ // __ \ / __  // _ \ / /|_/ // _ \ / __ \ / / / /
      / /|  // /_/ // /_/ //  __// /  / //  __// / / // /_/ /
-    /_/ |_/ \____/ \__,_/ \___//_/  /_/ \___//_/ /_/ \__,_/  v.1.0.0
+    /_/ |_/ \____/ \__,_/ \___//_/  /_/ \___//_/ /_/ \__,_/  v.1.3.5
 
     ---------------Main Menu---------------
     1. No parameters

--- a/lib/nodemenu.js
+++ b/lib/nodemenu.js
@@ -4,6 +4,7 @@
 var MenuItem = require('./menuitem');
 var MenuType = MenuItem.MenuType;
 var _    = require('underscore');
+var pkg  = require('../package.json');
 
 var NodeMenu = function() {
     var self = this;
@@ -266,7 +267,7 @@ NodeMenu.prototype._parseInput = function(text) {
         res.argv = match.slice(1);
         for (var i = 0; i < res.argv.length; ++i) {
             res.argv[i] = res.argv[i].replace(/"/g, '');
-            if (res.argv[i].trim !== '') {
+            if (res.argv[i].trim() !== '') {
                 var num = Number(res.argv[i]);
                 if (!isNaN(num)) {
                     res.argv[i] = num;
@@ -289,7 +290,7 @@ NodeMenu.prototype._printHeader = function() {
            / | / /____   ____/ /___   /  |/  /___   ____   __  __             \n\
           /  |/ // __ \\ / __  // _ \\ / /|_/ // _ \\ / __ \\ / / / /         \n\
          / /|  // /_/ // /_/ //  __// /  / //  __// / / // /_/ /              \n\
-        /_/ |_/ \\____/ \\__,_/ \\___//_/  /_/ \\___//_/ /_/ \\__,_/  v.1.0.0 \n\
+        /_/ |_/ \\____/ \\__,_/ \\___//_/  /_/ \\___//_/ /_/ \\__,_/  v." + pkg.version + " \n\
                                                                               \n\
                                                                               \n");
     } else if (_.isFunction(self.customHeaderFunc)) {
@@ -315,7 +316,7 @@ NodeMenu.prototype._printMenu = function() {
     self._printHeader();
     for (var i = 0; i < self.menuItems.length; ++i) {
         var menuItem = self.menuItems[i];
-        printableMenu = menuItem.getPrintableString();
+        var printableMenu = menuItem.getPrintableString();
         if (menuItem.menuType === MenuType.ACTION) {
             self.consoleOutput(menuItem.number + ". " + printableMenu);
         } else if (menuItem.menuType === MenuType.DELIMITER) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-menu",
   "description": "Allows to create command line menu for REPL applications",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": "Borys Nebosenko <borys.nebosenko@gmail.com>",
   "keywords": [
   	"menu", 


### PR DESCRIPTION
## Summary
- Fix `_parseInput` to call `.trim()` instead of comparing the function reference, so empty arguments are handled correctly
- Fix global variable leak by declaring `printableMenu` with `var` in `_printMenu`
- Read banner version from `package.json` instead of hardcoding `v.1.0.0`
- Fix README `continueCallback` example (was incorrectly showing `resetMenu()`)
- Bump version to 1.3.5

## Test plan
- [x] `node -e "require('./index')"` loads without error
- [x] Verified empty-string trim check behaves correctly
- [x] Verified `printableMenu` no longer leaks to global scope

Made with [Cursor](https://cursor.com)