### PR TITLE
Add package.json metadata for npm (1.3.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-menu",
   "description": "Allows to create command line menu for REPL applications",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "author": "Borys Nebosenko <borys.nebosenko@gmail.com>",
   "keywords": [
   	"menu", 
@@ -10,12 +10,22 @@
   	"console",
   	"terminal"
   ],
-  "repository": "git://github.com/nbu/node-menu",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/nbu/node-menu.git"
+  },
+  "main": "index.js",
+  "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "lib/"
+  ],
   "dependencies": {
   	"underscore": "1.13.8"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">=14"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Add `main` and `types` fields so entry point and TypeScript definitions are explicit
- Add `files` whitelist so dev files (`mise.toml`, `mise.lock`, `examples/`) are excluded from the npm tarball
- Update `engines.node` from `>= 0.10.0` to `>=14`
- Normalize `repository` to object format (fixes npm publish warning)
- Bump version to 1.3.6

## Test plan
- [x] `node -e "require('./index')"` loads without error
- [x] `npm publish --dry-run` tarball contains 7 files (no mise or examples)

Made with [Cursor](https://cursor.com)