### PR TITLE
Fix TypeScript definitions for singleton export (1.3.7)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,22 +1,23 @@
 declare namespace NodeMenu {
     interface args {
-        name: string,
-        type: 'numeric'|'bool'|'string'
+        name: string;
+        type: 'numeric' | 'bool' | 'string';
     }
 }
 
-declare class NodeMenu {
-    constructor();
-    enableDefaultHeader(): NodeMenu;
-    disableDefaultHeader(): NodeMenu;
-    customHeader(customHeaderFunc: Function): NodeMenu;
-    enableDefaultPrompt(): NodeMenu;
-    disableDefaultPrompt(): NodeMenu;
-    customPrompt(customPromptFunc: Function): NodeMenu;
-    resetMenu(): NodeMenu;
-    continueCallback(continueCallback: Function): NodeMenu;
-    addItem(title: string, handler: Function, owner?: any, args?: NodeMenu.args[]): NodeMenu;
-    addDelimiter(delimiter: string, cnt: number, title?: string): NodeMenu;
+interface NodeMenuInstance {
+    enableDefaultHeader(): NodeMenuInstance;
+    disableDefaultHeader(): NodeMenuInstance;
+    customHeader(customHeaderFunc: Function): NodeMenuInstance;
+    enableDefaultPrompt(): NodeMenuInstance;
+    disableDefaultPrompt(): NodeMenuInstance;
+    customPrompt(customPromptFunc: Function): NodeMenuInstance;
+    resetMenu(): NodeMenuInstance;
+    continueCallback(continueCallback: Function): NodeMenuInstance;
+    addItem(title: string, handler: Function, owner?: any, args?: NodeMenu.args[]): NodeMenuInstance;
+    addDelimiter(delimiter: string, cnt: number, title?: string): NodeMenuInstance;
     start(): void;
 }
+
+declare const NodeMenu: NodeMenuInstance;
 export = NodeMenu;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-menu",
   "description": "Allows to create command line menu for REPL applications",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "author": "Borys Nebosenko <borys.nebosenko@gmail.com>",
   "keywords": [
   	"menu", 


### PR DESCRIPTION
## Summary
- Replace `declare class NodeMenu` with `declare const NodeMenu: NodeMenuInstance` to match the runtime singleton export (`module.exports = new NodeMenu()`)
- Keep `NodeMenu.args` namespace for argument type definitions
- `new NodeMenu()` is now correctly rejected by the type checker
- Bump version to 1.3.7

## Test plan
- [x] `npx tsc --noEmit` against a sample consumer confirms valid usage type-checks
- [x] `npx tsc --noEmit` confirms `new NodeMenu()` is rejected

Made with [Cursor](https://cursor.com)