### PR TITLE
Remove underscore dependency (1.4.0)

### DIFF
--- a/lib/menuitem.js
+++ b/lib/menuitem.js
@@ -1,5 +1,3 @@
-var _    = require('underscore');
-
 var MenuType = {
 	ACTION     : 1,
 	DELIMITER  : 2
@@ -39,12 +37,12 @@ MenuItem.prototype.validate = function(argv) {
 
 	for (var i = 0; i < self.args.length; ++i) {
 		if (self.args[i].type === 'numeric') {
-			if (!_.isFinite(argv[i])) {
+			if (!Number.isFinite(argv[i])) {
 				typesMatch = false;
 				break;
 			}
 		} else if (self.args[i].type === 'bool') {
-			if (!_.isBoolean(argv[i])) {
+			if (typeof argv[i] !== 'boolean') {
 				typesMatch = false;
 				break;
 			}

--- a/lib/nodemenu.js
+++ b/lib/nodemenu.js
@@ -3,7 +3,6 @@
  */
 var MenuItem = require('./menuitem');
 var MenuType = MenuItem.MenuType;
-var _    = require('underscore');
 var pkg  = require('../package.json');
 
 var NodeMenu = function() {
@@ -131,7 +130,7 @@ NodeMenu.prototype.resetMenu = function() {
  */
 NodeMenu.prototype.continueCallback = function(continueCallback) {
     var self = this;
-    self.continueCallback = continueCallback && _.isFunction(continueCallback) ? continueCallback : undefined;
+    self.continueCallback = continueCallback && typeof continueCallback === 'function' ? continueCallback : undefined;
     return self;
 };
 
@@ -293,7 +292,7 @@ NodeMenu.prototype._printHeader = function() {
         /_/ |_/ \\____/ \\__,_/ \\___//_/  /_/ \\___//_/ /_/ \\__,_/  v." + pkg.version + " \n\
                                                                               \n\
                                                                               \n");
-    } else if (_.isFunction(self.customHeaderFunc)) {
+    } else if (typeof self.customHeaderFunc === 'function') {
         self.customHeaderFunc();
     }
 };
@@ -303,7 +302,7 @@ NodeMenu.prototype._printPrompt = function() {
 
     if (self.printDefaultPrompt) {
         self.consoleOutput('\nPlease provide input at prompt as: >> ItemNumber arg1 arg2 ... (i.e. >> 2 "string with spaces" 2 4 noSpacesString true)');
-    } else if (_.isFunction(self.customPromptFunc)) {
+    } else if (typeof self.customPromptFunc === 'function') {
         self.customPromptFunc();
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,16 @@
 {
   "name": "node-menu",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-menu",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "license": "MIT",
-      "dependencies": {
-        "underscore": "1.13.8"
-      },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">=14"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-menu",
   "description": "Allows to create command line menu for REPL applications",
-  "version": "1.3.7",
+  "version": "1.4.0",
   "author": "Borys Nebosenko <borys.nebosenko@gmail.com>",
   "keywords": [
   	"menu", 
@@ -21,9 +21,6 @@
     "index.d.ts",
     "lib/"
   ],
-  "dependencies": {
-  	"underscore": "1.13.8"
-  },
   "engines": {
     "node": ">=14"
   },


### PR DESCRIPTION
## Summary
- Replace `_.isFunction` with `typeof x === 'function'` (3 usages in `nodemenu.js`)
- Replace `_.isFinite` with `Number.isFinite` and `_.isBoolean` with `typeof x === 'boolean'` in `menuitem.js`
- Remove `underscore` from `dependencies` — **zero runtime dependencies**
- Bump version to 1.4.0

## Test plan
- [x] `node -e "require('./index')"` loads without error
- [x] `npm publish --dry-run` — 7 files, no underscore in tarball
- [x] `npm audit` — 0 vulnerabilities

Made with [Cursor](https://cursor.com)