### PR TITLE
Remove obsolete Additional links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,3 @@ Output of this example:
     >>
 
 To invoke item without arguments just type number and Enter. To invoke item with arguments, type number then arguments delimited with space. If string argument has spaces it must be double quoted.
-
-# Additional links
-
-Similar library for other languages:
-- [Java](https://github.com/nbu/java-menu)
-- [C#](https://github.com/nbu/charp-menu)


### PR DESCRIPTION
## Summary
- Remove the obsolete "Additional links" section from README
- Drops outdated references to Java and C# sibling libraries

## Test plan
- [x] README renders correctly without the removed section

Made with [Cursor](https://cursor.com)